### PR TITLE
Took care of logic goof that causes intermittent test failures

### DIFF
--- a/src/main/java/com/speakr/entity/Post.java
+++ b/src/main/java/com/speakr/entity/Post.java
@@ -95,9 +95,8 @@ public class Post {
         this.replies.remove(post);
     }
 
-    // TODO: Write tests for this
     public Set<Post> getReplies() {
-        return new HashSet<>();
+        return this.replies;
     }
 
     public Post() { }
@@ -106,6 +105,7 @@ public class Post {
         this.text = text;
         this.user = user;
         this.postTime = new Date();
+        this.replies = new HashSet<>();
     }
 
 }

--- a/src/test/java/com/speakr/entity/PostTest.java
+++ b/src/test/java/com/speakr/entity/PostTest.java
@@ -22,10 +22,21 @@ class PostTest {
     @Test
     void testGetReplies() {
         System.out.println("getReplies");
-//        fail("Haven't written test yet");
-        // The line above is commented out because I needed the commit to pass
-        // all the GitHub workflow tests prior to my taking a little break from
-        // this project.
+        User originalPoster = TestUserFactory.createNewUser();
+        Post post = TestPostFactory.makeNewPostFrom(originalPoster);
+        User respondent = TestUserFactory.giveUserOtherThan(originalPoster);
+        String replyText = "Couldn't agree more!";
+        Post reply = new Post(replyText, respondent);
+        post.addReply(reply);
+        Set<Post> replies = post.getReplies();
+        String msg = "Reply to \"" + post.getText() + "\" from "
+                + post.getUser().getDisplayName() + " should include reply \""
+                + replyText + "\" from " + respondent.getDisplayName();
+        assert replies.contains(reply) : msg;
     }
+
+    // TODO: Write test requiring getReplies() not to leak private field
+    //  reference. Though with the mockery that Spring makes of access
+    //  modifiers, this might be moot...
 
 }

--- a/src/test/java/com/speakr/entity/TestUserFactory.java
+++ b/src/test/java/com/speakr/entity/TestUserFactory.java
@@ -33,7 +33,7 @@ public class TestUserFactory {
      * @param user The user to check for recency. For example, James Public III.
      * @return If <code>user</code> was given by this test user factory, zero or
      * a positive integer, where zero indicates the most recently created user.
-     * Otherwise a negative integer, most likely &minus;1. Don't read any
+     * Otherwise, a negative integer, most likely &minus;1. Don't read any
      * particular significance into any other negative integer.
      */
     static int recency(User user) {
@@ -41,7 +41,7 @@ public class TestUserFactory {
         if (index < 0) {
             return index;
         } else {
-            return userCount - index;
+            return userCount - index - 1;
         }
     }
 

--- a/src/test/java/com/speakr/entity/TestUserFactory.java
+++ b/src/test/java/com/speakr/entity/TestUserFactory.java
@@ -26,9 +26,8 @@ public class TestUserFactory {
         return user;
     }
 
-    // TODO: Write tests for this
-    public int recency(User user) {
-        return Integer.MIN_VALUE;
+    static int recency(User user) {
+        return Math.abs(userCount - USER_LIST.indexOf(user) - 1);
     }
 
     public static User giveExistingUser() {

--- a/src/test/java/com/speakr/entity/TestUserFactory.java
+++ b/src/test/java/com/speakr/entity/TestUserFactory.java
@@ -26,6 +26,11 @@ public class TestUserFactory {
         return user;
     }
 
+    // TODO: Write tests for this
+    public int recency(User user) {
+        return Integer.MIN_VALUE;
+    }
+
     public static User giveExistingUser() {
         if (userCount == 0) {
             String excMsg = "No existing users to give";

--- a/src/test/java/com/speakr/entity/TestUserFactory.java
+++ b/src/test/java/com/speakr/entity/TestUserFactory.java
@@ -26,8 +26,23 @@ public class TestUserFactory {
         return user;
     }
 
+    /**
+     * Indicates how recently a user was created by this test user factory. Note
+     * that this function is package private, it is not intended for use outside
+     * this package.
+     * @param user The user to check for recency. For example, James Public III.
+     * @return If <code>user</code> was given by this test user factory, zero or
+     * a positive integer, where zero indicates the most recently created user.
+     * Otherwise a negative integer, most likely &minus;1. Don't read any
+     * particular significance into any other negative integer.
+     */
     static int recency(User user) {
-        return Math.abs(userCount - USER_LIST.indexOf(user) - 1);
+        int index = USER_LIST.indexOf(user);
+        if (index < 0) {
+            return index;
+        } else {
+            return userCount - index;
+        }
     }
 
     public static User giveExistingUser() {

--- a/src/test/java/com/speakr/entity/TestUserFactoryTest.java
+++ b/src/test/java/com/speakr/entity/TestUserFactoryTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,19 +13,10 @@ class TestUserFactoryTest {
 
     private static final Random RANDOM = new Random();
 
-    /**
-     * Set of all users created during one execution of this test class. Please
-     * be sure to add any User created by TestUserFactory.createNewUser() to
-     * this set. I am aware that the concern this addresses might be moot in
-     * JUnit. It might be relevant in TestNG, I don't know.
-     */
-    private static final Set<User> USER_SET = new HashSet<>();
-
     @Test
     void testCreateNewUser() {
         System.out.println("createNewUser");
         User user = TestUserFactory.createNewUser();
-        USER_SET.add(user);
         assert user.getUserName() != null : "User name should not be null";
         assert user.getDisplayName() != null
                 : "Display name should not be null";
@@ -39,7 +29,6 @@ class TestUserFactoryTest {
         for (int i = 0; i < expected; i++) {
             User user = TestUserFactory.createNewUser();
             users.add(user);
-            USER_SET.add(user);
         }
         int actual = users.size();
         String msg = "createNewUser() should have given " + expected
@@ -48,18 +37,43 @@ class TestUserFactoryTest {
     }
 
     @Test
+    void testRecency() {
+        System.out.println("recency");
+        User firstUser = TestUserFactory.createNewUser();
+        String msg = "Most recent new user should have recency 0";
+        assert TestUserFactory.recency(firstUser) == 0 : msg;
+        int leastRecency = RANDOM.nextInt(16) + 4;
+        String msgPart = firstUser.getDisplayName()
+                + " should now have recency ";
+        for (int expected = 1; expected < leastRecency; expected++) {
+            User latestNewUser = TestUserFactory.createNewUser();
+            assert TestUserFactory.recency(latestNewUser) == 0 : msg;
+            int actual = TestUserFactory.recency(firstUser);
+            String recencyMsg = msgPart + expected;
+            assertEquals(expected, actual, recencyMsg);
+        }
+    }
+
+    @Test
+    void testNegativeRecencyForNonFactoryCreatedUser() {
+        fail("Haven't written test yet");
+    }
+
+    @Test
     void testGiveExistingUser() {
+        System.out.println("giveExistingUser");
         int capacity = RANDOM.nextInt(64) + 16;
         List<User> users = new ArrayList<>(capacity);
         while (users.size() < capacity) {
             User user = TestUserFactory.createNewUser();
             users.add(user);
-            USER_SET.add(user);
         }
         User user = TestUserFactory.giveExistingUser();
         String msg = "giveExistingUser() gave user " + user.getUserName()
                 + " who should have already been given by createNewUser()";
-        assert USER_SET.contains(user) : msg;
+//        assert TestUserFactory.isFactoryGiven(user) : msg;
+//        assert USER_SET.contains(user) : msg;
+        fail("Figure out how to rewrite this test");
     }
 
     @Test
@@ -67,16 +81,9 @@ class TestUserFactoryTest {
         System.out.println("giveUserOtherThan");
         User user = TestUserFactory.createNewUser();
         User otherUser = TestUserFactory.giveUserOtherThan(user);
-        USER_SET.add(user);
-        USER_SET.add(otherUser);
         String msg = "giveUserOtherThan( ) should give user other than "
                 + user.getUserName();
         assertNotEquals(user, otherUser, msg);
-    }
-
-    @AfterEach
-    void reportUserSetSize() {
-        System.out.println("User set has " + USER_SET.size() + " users");
     }
 
 }

--- a/src/test/java/com/speakr/entity/TestUserFactoryTest.java
+++ b/src/test/java/com/speakr/entity/TestUserFactoryTest.java
@@ -63,7 +63,6 @@ class TestUserFactoryTest {
         int actual = TestUserFactory.recency(nonFactoryCreatedUser);
         String msg = "Given that this test class made " + displayName
                 + " rather than the factory, recency should be negative";
-        System.out.println(actual);
         assert actual < 0 : msg;
     }
 
@@ -79,9 +78,7 @@ class TestUserFactoryTest {
         User user = TestUserFactory.giveExistingUser();
         String msg = "giveExistingUser() gave user " + user.getUserName()
                 + " who should have already been given by createNewUser()";
-//        assert TestUserFactory.isFactoryGiven(user) : msg;
-//        assert USER_SET.contains(user) : msg;
-        fail("Figure out how to rewrite this test");
+        assert TestUserFactory.recency(user) > -1 : msg;
     }
 
     @Test
@@ -89,7 +86,7 @@ class TestUserFactoryTest {
         System.out.println("giveUserOtherThan");
         User user = TestUserFactory.createNewUser();
         User otherUser = TestUserFactory.giveUserOtherThan(user);
-        String msg = "giveUserOtherThan( ) should give user other than "
+        String msg = "giveUserOtherThan() should give user other than "
                 + user.getUserName();
         assertNotEquals(user, otherUser, msg);
     }

--- a/src/test/java/com/speakr/entity/TestUserFactoryTest.java
+++ b/src/test/java/com/speakr/entity/TestUserFactoryTest.java
@@ -56,7 +56,15 @@ class TestUserFactoryTest {
 
     @Test
     void testNegativeRecencyForNonFactoryCreatedUser() {
-        fail("Haven't written test yet");
+        String name = "Mxy";
+        String displayName = "Mr. Mxyzptlk";
+        String bio = "Superman's best friend, Supergirl's too";
+        User nonFactoryCreatedUser = new User(name, displayName, bio);
+        int actual = TestUserFactory.recency(nonFactoryCreatedUser);
+        String msg = "Given that this test class made " + displayName
+                + " rather than the factory, recency should be negative";
+        System.out.println(actual);
+        assert actual < 0 : msg;
     }
 
     @Test

--- a/src/test/java/com/speakr/service/MockPostService.java
+++ b/src/test/java/com/speakr/service/MockPostService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.speakr.entity.Post;
 import com.speakr.entity.User;
 import com.speakr.entity.Vote;
+import com.speakr.entity.TestPostFactory;
+import com.speakr.entity.TestUserFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;

--- a/src/test/java/com/speakr/service/MockPostServiceTest.java
+++ b/src/test/java/com/speakr/service/MockPostServiceTest.java
@@ -1,5 +1,6 @@
 package com.speakr.service;
 
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MockPostServiceTest {

--- a/src/test/java/com/speakr/service/MockUserService.java
+++ b/src/test/java/com/speakr/service/MockUserService.java
@@ -2,6 +2,8 @@ package com.speakr.service;
 
 import com.speakr.dao.UserDAO;
 import com.speakr.entity.User;
+import com.speakr.entity.TestPostFactory;
+import com.speakr.entity.TestUserFactory;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/speakr/service/MockUserServiceTest.java
+++ b/src/test/java/com/speakr/service/MockUserServiceTest.java
@@ -1,5 +1,6 @@
 package com.speakr.service;
 
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MockUserServiceTest {


### PR DESCRIPTION
Originally, `TestUserFactoryTest` kept a list of users given by `TestUserFactory`. This was no problem until other test classes started also using `TestUserFactory`. For example, if `TestUserFactory` made James Public XXII for `PostTest`, then `TestUserFactoryTest` would be unaware of that user, and so the give existing user test could potentially fail.

To address that problem, I introduced the concept of recency: users created by `TestUserFactory` have zero or positive recency, while other users have negative recency. Then I amended the give existing user test to check the recency of the user expected to already exist prior to the test. I also deleted `TestUserFactoryTest`'s list of users given by `TestUserFactory`.

Hopefully this causes no more hard-to-reproduce intermittent test failures.